### PR TITLE
Make notifications a little less agressive

### DIFF
--- a/lua/url-open/modules/handlers.lua
+++ b/lua/url-open/modules/handlers.lua
@@ -112,9 +112,9 @@ M.open_url_with_app = function(apps, url)
 				detach = true,
 				on_exit = function(_, code, _)
 					if code ~= 0 then
-						require("url-open.modules.logger").error("Opening " .. url .. " failed.")
+						require("url-open.modules.logger").error("Failed to open " .. url)
 					else
-						require("url-open.modules.logger").info("Opening " .. url .. " successfully.")
+						require("url-open.modules.logger").info("Opening " .. url)
 					end
 				end,
 			})

--- a/lua/url-open/modules/logger.lua
+++ b/lua/url-open/modules/logger.lua
@@ -10,21 +10,21 @@ local schedule = vim.schedule
 --- @tparam string msg : The message to show
 --- @tparam[opt] table opts : The options to pass to vim.notify
 M.info = function(msg, opts)
-	schedule(function() notify(msg, levels.INFO, opts or { title = "URL OPEN INFO" }) end)
+	schedule(function() notify(msg, levels.INFO, opts or { title = "url-open" }) end)
 end
 
 --- Show warn level notification
 --- @tparam string msg : The message to show
 --- @tparam[opt] table opts : The options to pass to vim.notify
 M.warn = function(msg, opts)
-	schedule(function() notify(msg, levels.WARN, opts or { title = "URL OPEN WARNING" }) end)
+	schedule(function() notify(msg, levels.WARN, opts or { title = "url-open" }) end)
 end
 
 --- Show error level notification
 --- @tparam string msg : The message to show
 --- @tparam[opt] table opts : The options to pass to vim.notify
 M.error = function(msg, opts)
-	schedule(function() notify(msg, levels.ERROR, opts or { title = "URL OPEN ERROR" }) end)
+	schedule(function() notify(msg, levels.ERROR, opts or { title = "url-open" }) end)
 end
 
 return M


### PR DESCRIPTION
- The title of the notifications now contains the lowercased plugin name
- Verbiage of the success / failure notifications is cleaner (no need to say it's an error if the notifications framework will style it like an error)

![image](https://github.com/sontungexpt/url-open/assets/20600565/de0d94df-b837-4101-9cc8-8fa8263e4b1f)


This plugin is great! Thanks :)